### PR TITLE
add extension to configure qmstr address

### DIFF
--- a/src/main/java/org/qmstr/gradle/QmstrCompileTask.java
+++ b/src/main/java/org/qmstr/gradle/QmstrCompileTask.java
@@ -21,6 +21,11 @@ public class QmstrCompileTask extends QmstrTask {
 
     @TaskAction
     void build() {
+        QmstrPluginExtension extension = (QmstrPluginExtension) getProject()
+                .getExtensions().findByName("qmstr");
+
+        this.setBuildServiceAddress(extension.qmstrAddress);
+
         bsc = new BuildServiceClient(buildServiceAddress, buildServicePort);
 
         this.sourceSets.forEach(set -> {

--- a/src/main/java/org/qmstr/gradle/QmstrPackTask.java
+++ b/src/main/java/org/qmstr/gradle/QmstrPackTask.java
@@ -21,6 +21,11 @@ public class QmstrPackTask extends QmstrTask {
 
     @TaskAction
     void pack() {
+        QmstrPluginExtension extension = (QmstrPluginExtension) getProject()
+                .getExtensions().findByName("qmstr");
+
+        this.setBuildServiceAddress(extension.qmstrAddress);
+
         bsc = new BuildServiceClient(buildServiceAddress, buildServicePort);
 
         HashMap<PublishArtifact, Set<File>> arts = new HashMap<>();

--- a/src/main/java/org/qmstr/gradle/QmstrPlugin.java
+++ b/src/main/java/org/qmstr/gradle/QmstrPlugin.java
@@ -12,13 +12,10 @@ import java.util.Collections;
 import java.util.Set;
 
 public class QmstrPlugin implements Plugin<Project> {
-    String address = "localhost:50051";
 
     public void apply(Project project) {
-        String difAddress = System.getenv("QMSTR_ADDRESS");
-        if (difAddress != null && !difAddress.trim().isEmpty()){
-            address = difAddress;
-        }
+        project.getExtensions().create("qmstr", QmstrPluginExtension.class);
+
         project.getPluginManager().apply(JavaPlugin.class);
         project.getPluginManager().apply(DistributionPlugin.class);
 
@@ -32,14 +29,12 @@ public class QmstrPlugin implements Plugin<Project> {
         Set<Task> classes = project.getTasksByName("classes", false);
 
         Task qmstrCompile = project.getTasks().create("qmstrbuild", QmstrCompileTask.class, (task) -> {
-            task.setBuildServiceAddress(address);
             task.setSourceSets(getJavaSourceSets(project));
             task.dependsOn(classes);
         });
 
         project.getTasks().create("qmstr", QmstrPackTask.class, (task) -> {
             task.dependsOn(qmstrCompile, jarTask);
-            task.setBuildServiceAddress(address);
             task.setProjectConfig(project.getConfigurations());
         });
     }

--- a/src/main/java/org/qmstr/gradle/QmstrPluginExtension.java
+++ b/src/main/java/org/qmstr/gradle/QmstrPluginExtension.java
@@ -1,0 +1,14 @@
+package org.qmstr.gradle;
+
+public class QmstrPluginExtension {
+    String qmstrAddress;
+
+    public QmstrPluginExtension() {
+        this.qmstrAddress = "localhost:50051";
+
+        String difAddress = System.getenv("QMSTR_ADDRESS");
+        if (difAddress != null && !difAddress.trim().isEmpty()){
+            this.qmstrAddress = difAddress;
+        }
+    }
+}


### PR DESCRIPTION
Add extension to configure the address of the qmstr master server in the
build.gradle.

Behavior:
1. address defaults to localhost:50051
2. use QMSTR_ADDRESS environment variable
3. use address configured in build.gradle e.g.
qmstr {
  qmstrAdress = "masterhostname:12345"
}